### PR TITLE
test(launch): simple testing job

### DIFF
--- a/jobs/hello_world/job.py
+++ b/jobs/hello_world/job.py
@@ -1,6 +1,75 @@
 import wandb
+import random
+from wandb.sdk import launch
+import re
+import requests
 
-settings = wandb.Settings(disable_git=True)
+job_input_schema = {
+    "type": "object",
+    "properties": {
+        "lower_bound": {
+            "type": "number",
+            "description": "Lower bound of the range",
+        },
+        "upper_bound": {
+            "type": "string",
+            "description": "Upper bound of the range",
+        },
+        "log_a_message": {
+            "type": "boolean",
+            "description": "Log a message to the console",
+        },
+        "api_key": {
+            "type": "string",
+            "description": "API key to use",
+        },
+    },
+}
+
+settings = wandb.Settings(
+    disable_git=True,
+    job_source="image",
+    disable_job_creation=False
+)
+
+def make_name_dns_safe(name: str) -> str:
+    resp = name.replace("_", "-").lower()
+    resp = re.sub(r"[^a-z\.\-]", "", resp)
+    # Actual length limit is 253, but we want to leave room for the generated suffix
+    resp = resp[:200]
+    return resp
 
 with wandb.init(settings=settings) as run:
-    run.log({"hello": "world"})
+    
+    launch.manage_wandb_config(
+        include=["lower_bound", "upper_bound", "log_a_message", "api_key"],
+        schema=job_input_schema,
+    )
+    
+    lower_bound = run.config.get("lower_bound", 0)
+    upper_bound = run.config.get("upper_bound", 10)
+    log_a_message = run.config.get("log_a_message", False)
+    api_key = run.config.get("api_key", "1234567890")
+    
+    for i in range(lower_bound, upper_bound):
+        run.log({
+            "step": i, 
+            "a": random.random(), 
+            "b": random.random(), 
+            "c": random.random(),
+        })
+        
+    service_name = make_name_dns_safe(f"ping-service-{run.entity}-{run.project}-{run.id}")
+    url = f"http://{service_name}:8080"
+    response = requests.get(f"{url}/ping")
+    
+    if log_a_message:
+        print(response.text)
+        
+    run.log({
+        "api_key": api_key,
+        "response": response.text
+    })  
+    
+    
+    

--- a/jobs/hello_world/requirements.txt
+++ b/jobs/hello_world/requirements.txt
@@ -1,1 +1,2 @@
 wandb
+wandb[launch]


### PR DESCRIPTION
## How to use

Build image and create job:
```
cd jobs/hello_world
docker build --platform linux/amd64 -t <your-tag> -f Dockerfile.wandb . --push
wandb job create --project <your-project> -e <your-entity> -n <job-name> image <image-from-above>
```

The job in its current state will also require the queue config below to deploy an additional service. For testing without the service, commenting out the bottom couple of lines will leave the job to only log some numeric values.

Also note that the input configs schema UI will not trigger on the FE ... I'm trying to figure that out rn. `wandb job create` doesn't add `input_types` into the job JSON. You can still modify inputs on the first job run via job overrides by modifying the `run_config` key, e.g:
```
    "run_config": {
        "api_key": "foobar123",
        "lower_bound": 1,
        "upper_bound": 10,
        "log_a_message": true
    },
```
The job will work regardless of it receiving input in this manner though, so feel free to ignore this!

## Queue Config

<details>
<summary>Deployment</summary>

```
kind: Deployment
spec:
  replicas: 2
  selector:
    matchLabels:
      app: test-ping-server
  template:
    spec:
      containers:
        - name: ping-server
          image: python:3.9-slim
          ports:
            - containerPort: 8080
          command:
            - sh
            - -c
            - |-
              cat > server.py << 'EOF'
              import http.server
              import socketserver
              import json
              import time
              import threading

              startup_time = time.time()
              ready = False

              def mark_ready():
                  time.sleep(15)
                  global ready
                  ready = True
                  print('Server is now ready to serve health checks!')

              threading.Thread(target=mark_ready, daemon=True).start()

              class Handler(http.server.BaseHTTPRequestHandler):
                  def do_GET(self):
                      if self.path == '/ping':
                          self.send_response(200)
                          self.send_header('Content-type', 'application/json')
                          self.end_headers()
                          response = {
                              'status': 'ok',
                              'message': 'Hello from Kubernetes!',
                              'pod': 'test-ping-server',
                              'uptime': round(time.time() - startup_time, 1),
                              'ready': ready
                          }
                          self.wfile.write(json.dumps(response).encode())
                      elif self.path == '/health':
                          if ready:
                              self.send_response(200)
                              self.send_header('Content-type', 'text/plain')
                              self.end_headers()
                              self.wfile.write(b'healthy')
                          else:
                              self.send_response(503)
                              self.send_header('Content-type', 'text/plain')
                              self.end_headers()
                              self.wfile.write(b'starting up...')
                      else:
                          self.send_response(404)
                          self.end_headers()
                          self.wfile.write(b'Not Found')
                  
                  def log_message(self, format, *args):
                      print(f'{self.address_string()} - {format % args}')

              print('Starting server... (will be ready in 15 seconds)')
              with socketserver.TCPServer(('', 8080), Handler) as httpd:
                  print('Server running on port 8080...')
                  httpd.serve_forever()
              EOF
              python server.py
          resources:
            limits:
              cpu: 200m
              memory: 256Mi
            requests:
              cpu: 100m
              memory: 128Mi
          livenessProbe:
            httpGet:
              path: /health
              port: 8080
            periodSeconds: 5
            timeoutSeconds: 1
            failureThreshold: 3
            initialDelaySeconds: 20
          readinessProbe:
            httpGet:
              path: /health
              port: 8080
            periodSeconds: 2
            timeoutSeconds: 1
            failureThreshold: 3
            successThreshold: 1
            initialDelaySeconds: 2
    metadata:
      labels:
        app: test-ping-server
metadata:
  name: test-ping-server
  labels:
    app: test-ping-server
apiVersion: apps/v1
```
</details>


<details>
<summary>Service</summary>

```
kind: Service
spec:
  type: ClusterIP
  ports:
    - name: http
      port: 8080
      protocol: TCP
      targetPort: 8080
  selector:
    app: test-ping-server
metadata:
  name: ping-service
  labels:
    app: test-ping-server
apiVersion: v1
```
</details>

## Queue Config with macros

<details>
<summary>Deployment</summary>

```
kind: Deployment
spec:
  replicas: 2
  selector:
    matchLabels:
      app: test-ping-server-${entity_name}-${project_name}-${run_id}
      wandb.ai/auxiliary-resource: aux-${entity_name}-${project_name}-${run_id}
  template:
    spec:
      containers:
        - name: ping-server-${entity_name}-${project_name}-${run_id}
          image: python:3.9-slim
          ports:
            - containerPort: 8080
          command:
            - sh
            - -c
            - |-
              cat > server.py << 'EOF'
              import http.server
              import socketserver
              import json
              import time
              import threading

              startup_time = time.time()
              ready = False

              def mark_ready():
                  time.sleep(15)
                  global ready
                  ready = True
                  print('Server is now ready to serve health checks!')

              threading.Thread(target=mark_ready, daemon=True).start()

              class Handler(http.server.BaseHTTPRequestHandler):
                  def do_GET(self):
                      if self.path == '/ping':
                          self.send_response(200)
                          self.send_header('Content-type', 'application/json')
                          self.end_headers()
                          response = {
                              'status': 'ok',
                              'message': 'Hello from Kubernetes!',
                              'pod': 'test-ping-server',
                              'uptime': round(time.time() - startup_time, 1),
                              'ready': ready
                          }
                          self.wfile.write(json.dumps(response).encode())
                      elif self.path == '/health':
                          if ready:
                              self.send_response(200)
                              self.send_header('Content-type', 'text/plain')
                              self.end_headers()
                              self.wfile.write(b'healthy')
                          else:
                              self.send_response(503)
                              self.send_header('Content-type', 'text/plain')
                              self.end_headers()
                              self.wfile.write(b'starting up...')
                      else:
                          self.send_response(404)
                          self.end_headers()
                          self.wfile.write(b'Not Found')
                  
                  def log_message(self, format, *args):
                      print(f'{self.address_string()} - {format % args}')

              print('Starting server... (will be ready in 15 seconds)')
              with socketserver.TCPServer(('', 8080), Handler) as httpd:
                  print('Server running on port 8080...')
                  httpd.serve_forever()
              EOF
              python server.py
          resources:
            limits:
              cpu: 200m
              memory: 256Mi
            requests:
              cpu: 100m
              memory: 128Mi
          livenessProbe:
            httpGet:
              path: /health
              port: 8080
            periodSeconds: 5
            timeoutSeconds: 1
            failureThreshold: 3
            initialDelaySeconds: 20
          readinessProbe:
            httpGet:
              path: /health
              port: 8080
            periodSeconds: 2
            timeoutSeconds: 1
            failureThreshold: 3
            successThreshold: 1
            initialDelaySeconds: 2
    metadata:
      labels:
        app: test-ping-server-${entity_name}-${project_name}-${run_id}
        wandb.ai/auxiliary-resource: aux-${entity_name}-${project_name}-${run_id}
metadata:
  name: test-ping-server-${entity_name}-${project_name}-${run_id}
  labels:
    app: test-ping-server-${entity_name}-${project_name}-${run_id}
    wandb.ai/auxiliary-resource: aux-${entity_name}-${project_name}-${run_id}
apiVersion: apps/v1
```
</details>

<details>
<summary>Service</summary>

```
kind: Service
spec:
  type: ClusterIP
  ports:
    - name: http
      port: 8080
      protocol: TCP
      targetPort: 8080
  selector:
    app: test-ping-server-${entity_name}-${project_name}-${run_id}
    wandb.ai/auxiliary-resource: aux-${entity_name}-${project_name}-${run_id}
metadata:
  name: ping-service-${entity_name}-${project_name}-${run_id}
  labels:
    app: test-ping-server-${entity_name}-${project_name}-${run_id}
    wandb.ai/auxiliary-resource: aux-${entity_name}-${project_name}-${run_id}
apiVersion: v1
```
</details>

<details>
<summary>Job Network Policy</summary>

```
kind: NetworkPolicy
spec:
  egress:
    - to:
        - podSelector:
            matchLabels:
              wandb.ai/run-id: ${run_id}
              wandb.ai/auxiliary-resource: aux-${entity_name}-${project_name}-${run_id}
      ports:
        - port: 8080
          protocol: TCP
    - to:
        - ipBlock:
            cidr: 0.0.0.0/0
      ports:
        - port: 80
          protocol: TCP
        - port: 443
          protocol: TCP
    - to:
        - namespaceSelector:
            matchLabels:
              name: kube-system
      ports:
        - port: 53
          protocol: UDP
        - port: 53
          protocol: TCP
  podSelector:
    matchLabels:
      wandb.ai/run-id: ${run_id}
      wandb.ai/monitor: "true"
  policyTypes:
    - Egress
metadata:
  name: job-policy-${entity_name}-${project_name}-${run_id}
  labels:
    wandb.ai/run-id: ${run_id}
    wandb.ai/created-by: launch-agent
    wandb.ai/auxiliary-resource: aux-${entity_name}-${project_name}-${run_id}
apiVersion: networking.k8s.io/v1
```
</details>

<details>
<summary>Resource Network Policy</summary>

```
kind: NetworkPolicy
spec:
  egress:
    - to:
        - namespaceSelector:
            matchLabels:
              name: kube-system
      ports:
        - port: 53
          protocol: UDP
        - port: 53
          protocol: TCP
    - to:
        - ipBlock:
            cidr: 0.0.0.0/0
      ports:
        - port: 80
          protocol: TCP
        - port: 443
          protocol: TCP
  ingress:
    - from:
        - podSelector:
            matchLabels:
              wandb.ai/run-id: ${run_id}
              wandb.ai/monitor: "true"
      ports:
        - port: 8080
          protocol: TCP
  podSelector:
    matchLabels:
      wandb.ai/run-id: ${run_id}
      wandb.ai/auxiliary-resource: aux-${entity_name}-${project_name}-${run_id}
  policyTypes:
    - Egress
    - Ingress
metadata:
  name: resource-policy-${entity_name}-${project_name}-${run_id}
  labels:
    wandb.ai/run-id: ${run_id}
    wandb.ai/created-by: launch-agent
    wandb.ai/auxiliary-resource: aux-${entity_name}-${project_name}-${run_id}
apiVersion: networking.k8s.io/v1
```
</details>
