### PR TITLE
ci: update ruff action to latest supported version

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -5,6 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: chartboost/ruff-action@v1
+      - uses: astral-sh/ruff-action@v3
         with:
-          args: --fix --exit-non-zero-on-fix --show-fixes --ignore E501
+          args: "check --fix --exit-non-zero-on-fix --show-fixes --ignore E501"


### PR DESCRIPTION
## Description 

`chartboost/ruff-action` is deprecated (https://github.com/ChartBoost/ruff-action?tab=readme-ov-file) and they recommend moving to https://github.com/astral-sh/ruff-action.

Updates the workflow to use the latest supported version

## Testing

Ran the command locally (and the action should run on this PR)