### PR TITLE
chore(launch): allow user-defined model names and re-enable base URL

### DIFF
--- a/jobs/inspect_ai_evals/evals.py
+++ b/jobs/inspect_ai_evals/evals.py
@@ -12,50 +12,36 @@ from leaderboard import create_leaderboard
 from launch_secrets import get_launch_secret_from_env
 from datasets.exceptions import DatasetNotFoundError
 
-def get_provider_from_model_name(model_name: str) -> str:
-    if model_name.startswith("anthropic/"):
-        return "anthropic"
-    elif model_name.startswith("openai/"):
-        return "openai"
-    elif model_name.startswith("google/"):
-        return "google"
-    else:
-        raise ValueError(f"Invalid model name: {model_name}")
-
-PROVIDER_TO_API_KEY_ENV = {
-    "anthropic": "ANTHROPIC_API_KEY",
-    "openai": "OPENAI_API_KEY",
-    "google": "GOOGLE_API_KEY",
-}
-
 def main():
     with wandb.init(config=launch.load_wandb_config()) as run:
         weave_client = weave.init(f"{run.entity}/{run.project}")
 
-        hf_token = get_launch_secret_from_env("hf_token", run.config)
+        _, hf_token = get_launch_secret_from_env("hf_token", run.config)
         if hf_token:
             os.environ.setdefault("HUGGINGFACE_HUB_TOKEN", hf_token)
             os.environ.setdefault("HF_TOKEN", hf_token)
             os.environ.setdefault("HUGGINGFACE_TOKEN", hf_token)
 
-        api_key = get_launch_secret_from_env("api_key_var", run.config["model"])
-        model_name = run.config["model"]["model_name"]
-        if api_key:
-            os.environ.setdefault(PROVIDER_TO_API_KEY_ENV[get_provider_from_model_name(model_name)], api_key)
-        else:
-            wandb.termerror(f"API key for model {model_name} not found")
-            weave_client.finish()
-            raise ValueError(f"API key for model {model_name} not found")
+        api_key_name, api_key = get_launch_secret_from_env("api_key_var", run.config.get("model", {}))
+        if api_key_name and api_key:
+            os.environ.setdefault(api_key_name, api_key)
 
         # Some evals use an OpenAI model as the default scorer.
         # Otherwise, we can use the model selected by the user (see INSPECT_GRADER_MODEL)
-        scorer_api_key = get_launch_secret_from_env("scorer_api_key", run.config)
+        _, scorer_api_key = get_launch_secret_from_env("scorer_api_key", run.config)
         if scorer_api_key:
             os.environ.setdefault("OPENAI_API_KEY", scorer_api_key)
 
         try:
-            model = get_model(model_name, api_key=api_key)
-                
+            model_name = run.config.get("model", {}).get("model_name")
+            base_url = run.config.get("model", {}).get("base_url", None)
+            if not model_name:
+                wandb.termerror("Hint: Model name is required")
+                weave_client.finish()
+                return
+
+            model = get_model(model_name, api_key=api_key, base_url=base_url)
+
             os.environ.setdefault("INSPECT_EVAL_MODEL", model_name)
             os.environ.setdefault("INSPECT_GRADER_MODEL", model_name)
         except Exception as e:

--- a/jobs/inspect_ai_evals/launch_secrets.py
+++ b/jobs/inspect_ai_evals/launch_secrets.py
@@ -4,15 +4,15 @@ from typing import Optional
 SECRET_REF_PREFIX = "secret://"
 
 
-def get_launch_secret_from_env(secret_key: str, config_dict: dict) -> Optional[str]:
+def get_launch_secret_from_env(secret_key: str, config_dict: dict) -> tuple[Optional[str], Optional[str]]:
     """
     Get a secret from the environment.
     """
     secret_ref = config_dict.get(secret_key)
     if secret_ref is None:
-        return None
+        return None, None
     env_key = secret_ref.replace(SECRET_REF_PREFIX, "").upper()
     secret_value = os.getenv(env_key)
     if secret_value is None:
-        return None
-    return secret_value
+        return None, None
+    return env_key, secret_value

--- a/jobs/inspect_ai_evals/sample-schema.json
+++ b/jobs/inspect_ai_evals/sample-schema.json
@@ -120,35 +120,12 @@
         "model_name": {
           "type": "string",
           "title": "Model name",
-          "description": "Name of the model to use for the evaluation job",
-          "enum": [
-            "openai/chatgpt-4o-latest",
-            "openai/gpt-3.5-turbo",
-            "openai/gpt-4",
-            "openai/gpt-4-turbo",
-            "openai/gpt-4.1",
-            "openai/gpt-4.1-mini",
-            "openai/gpt-4.1-nano",
-            "openai/gpt-4o",
-            "openai/gpt-4o-mini",
-            "openai/gpt-5",
-            "openai/gpt-5-chat-latest",
-            "openai/gpt-5-mini",
-            "openai/gpt-5-nano",
-            "openai/gpt-audio",
-            "openai/o1",
-            "openai/o1-mini",
-            "openai/o1-pro",
-            "openai/o3",
-            "openai/o3-mini",
-            "openai/o3-pro",
-            "openai/o4-mini",
-            "anthropic/claude-opus-4-1",
-            "anthropic/claude-opus-4-0",
-            "anthropic/claude-sonnet-4-0",
-            "anthropic/claude-3-7-sonnet-latest",
-            "anthropic/claude-3-5-haiku-latest"
-          ]
+          "description": "Name of the model to use for the evaluation job (e.g. openai/gpt-4o)"
+        },
+        "base_url": {
+          "type": "string",
+          "title": "Base URL",
+          "description": "Base URL for the model to use for the evaluation job (e.g. https://api.openai.com/v1)"
         },
         "api_key_var": {
           "type": "string",


### PR DESCRIPTION
Make both model name and base URL text entry fields in the inputs for the API-hosted evals job.

This will give users a bit more freedom to use their own custom providers and we will replace this with the providers component from playgrounds in the future