### PR TITLE
chore(launch): append exception object on failed tasks

### DIFF
--- a/jobs/inspect_ai_evals/api_model/evals.py
+++ b/jobs/inspect_ai_evals/api_model/evals.py
@@ -66,7 +66,7 @@ def main():
                 
                 if not success:
                     wandb.termerror(f"Task {task} did not run successfully")
-                    failed_tasks.append(task)
+                    failed_tasks.append((task, Exception("Task did not complete successfully. Check the logs for more details.")))
                     continue
                 
                 if run.config.get("create_leaderboard", True):

--- a/jobs/inspect_ai_evals/model_checkpoint/evals_model_checkpoint.py
+++ b/jobs/inspect_ai_evals/model_checkpoint/evals_model_checkpoint.py
@@ -103,18 +103,20 @@ def main():
                 
                 if not success:
                     wandb.termerror(f"Task {task} did not run successfully")
-                    failed_tasks.append(task)
+                    failed_tasks.append((task, Exception("Task did not complete successfully. Check the logs for more details.")))
                     continue
                 
                 if run.config.get("create_leaderboard", True):
                     create_leaderboard()
                     
-            except Exception:
+            except Exception as e:
                 wandb.termerror(f"Task {task} failed to run")
-                failed_tasks.append(task)
+                failed_tasks.append((task, e))
                 
         if failed_tasks:
-            wandb.termerror(f"Failed to run tasks: {failed_tasks}")
+            wandb.termerror(f"The following tasks failed to run: {[task for (task, _) in failed_tasks]}")
+            for task, e in failed_tasks:
+                wandb.termerror(f"Task {task} failed to run with error: {e}")
             run.finish(exit_code=1)
 
         weave_client.finish()


### PR DESCRIPTION
Was getting the following error when a task didn't succeed for the API-hosted endpoint job:

```
2025-10-29 20:19:18
wandb: ERROR Task inspect_evals/healthbench did not run successfully
2025-10-29 20:19:18
Traceback (most recent call last):
2025-10-29 20:19:18
  File "/workspace/evals.py", line 80, in main
2025-10-29 20:19:18
    wandb.termerror(f"The following tasks failed to run: {[task for (task, _) in failed_tasks]}")
2025-10-29 20:19:18
                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-10-29 20:19:18
  File "/workspace/evals.py", line 80, in <listcomp>
2025-10-29 20:19:18
    wandb.termerror(f"The following tasks failed to run: {[task for (task, _) in failed_tasks]}")
2025-10-29 20:19:18
                                                                    ^^^^^^^^^
2025-10-29 20:19:18
ValueError: too many values to unpack (expected 2)
```

The PR does 2 things: 
* Attaches an exception with the task so that the data structure is consistent when we log the failed tasks
* Adds the same error logs to the model checkpoint job
