### PR TITLE
chore(inspect_ai_evals): update dependencies for API-hosted model job

### DIFF
--- a/jobs/inspect_ai_evals/api_model/sample-schema.json
+++ b/jobs/inspect_ai_evals/api_model/sample-schema.json
@@ -11,7 +11,6 @@
       "items": {
         "type": "string",
         "enum": [
-          "agent_bench_os",
           "agentharm",
           "agentharm_benign",
           "agentic_misalignment",

--- a/jobs/inspect_ai_evals/pyproject.toml
+++ b/jobs/inspect_ai_evals/pyproject.toml
@@ -12,8 +12,7 @@ dependencies = [
     "black>=25.1.0",
     "huggingface-hub>=0.31.1",
     "inspect-ai>=0.3.69",
-    "inspect-evals",
-    "inspect-evals[ifeval]",
+    "inspect-evals[ifeval,sevenllm]",
     "inspect-wandb[weave]",
     "openai==2.0.0",
     "pandas>=2.2.3",
@@ -26,11 +25,13 @@ dependencies = [
     "weave>=0.51.59",
     "google-genai",
     "rouge",
+    "instruction-following-eval",
 ]
 
 [tool.uv.sources]
 inspect-evals = { git = "https://github.com/UKGovernmentBEIS/inspect_evals" }
 inspect-wandb = { git = "https://github.com/parambharat/inspect_wandb.git" }
+instruction-following-eval = { git = "https://github.com/josejg/instruction_following_eval.git" }
 
 [tool.inspect-wandb.weave]
 enabled = true


### PR DESCRIPTION
* Removes `agent_bench_os`, this eval requires a sandbox environment (see https://wandb.ai/wandb/launch-tutorial/runs/f441ymrs/logs?nw=nwusernicholaspun)
* Updates dependencies to support `sevenllm_qa_en` and `sevenllm_qa_zh` (see https://wandb.ai/wandb/launch-tutorial/runs/rf3ejkke/logs?nw=nwusernicholaspun and https://wandb.ai/wandb/launch-tutorial/runs/b0qw1pax/logs?nw=nwusernicholaspun)
* Updates dependencies to support `ifeval` (https://wandb.ai/wandb/launch-tutorial/runs/diwg77ig/logs?nw=nwusernicholaspun)

Verified this all works by running this locally: https://wandb.ai/wandb/launch-tutorial/jobs/QXJ0aWZhY3RDb2xsZWN0aW9uOjc5Njg4OTU1OA==/runs/latest
