### PR TITLE
chore(inspect_ai_evals): resolve openai version to be >=2.8.0

### DIFF
--- a/jobs/inspect_ai_evals/pyproject.toml
+++ b/jobs/inspect_ai_evals/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "inspect-ai>=0.3.69",
     "inspect-evals[bold,ifeval,sevenllm]",
     "inspect-wandb[weave]",
-    "openai==2.0.0",
+    "openai>=2.8.0",
     "pandas>=2.2.3",
     "pyarrow>=20.0.0",
     "pydantic==2.11.7",


### PR DESCRIPTION
Working with `nicholaspun/test-evals-api-hosted:v2`:
* https://wandb.ai/wandb/launch-tutorial/runs/putmvcyg?nw=nwusernicholaspun
* https://wandb.ai/wandb/launch-tutorial/runs/22gu4noi?nw=nwusernicholaspun

Here's the package versions:
```
docker run --rm nicholaspun/test-evals-api-hosted:v2 pip freeze
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
abnf==2.2.0
aioboto3==15.5.0
aiobotocore==2.25.1
aiofiles==25.1.0
aiohappyeyeballs==2.6.1
aiohttp==3.13.2
aioitertools==0.13.0
aiosignal==1.4.0
annotated-types==0.7.0
anthropic==0.74.1
anyio==4.11.0
attrs==25.4.0
backoff==2.2.1
beautifulsoup4==4.14.2
black==25.11.0
boto3==1.40.61
botocore==1.40.61
cachetools==6.2.2
certifi==2025.11.12
cffi==2.0.0
chardet==5.2.0
charset-normalizer==3.4.4
cint==1.0.0
click==8.2.1
cryptography==46.0.3
datasets==4.4.1
debugpy==1.8.17
detoxify==0.5.2
dill==0.4.0
diskcache==5.6.3
distro==1.9.0
docstring_parser==0.17.0
eval_type_backport==0.3.0
fickling==0.1.5
filelock==3.20.0
frozendict==2.4.7
frozenlist==1.8.0
fsspec==2025.9.0
gitdb==4.0.12
GitPython==3.1.45
google-auth==2.43.0
google-genai==1.52.0
gql==4.0.0
graphql-core==3.2.7
graphviz==0.21
h11==0.16.0
hf-xet==1.2.0
httpcore==1.0.9
httpx==0.28.1
huggingface-hub==0.36.0
idna==3.11
ijson==3.4.0.post0
immutabledict==4.2.2
inspect_ai==0.3.147
inspect_evals @ git+https://github.com/UKGovernmentBEIS/inspect_evals@cef800f4b6996170a0f1f3827e17529921b677d3
inspect_wandb @ git+https://github.com/parambharat/inspect_wandb.git@bca802699a9f8d4089e17765eff0ee907f132a0e
instruction_following_eval @ git+https://github.com/josejg/instruction_following_eval.git@0c495b2f95155e8b10acb919ae283bfb4d5be6e2
intervaltree==3.1.0
jieba==0.42.1
Jinja2==3.1.6
jiter==0.12.0
jmespath==1.0.1
joblib==1.5.2
jsonlines==4.0.0
jsonpatch==1.33
jsonpath-ng==1.7.0
jsonpointer==3.0.0
jsonref==1.1.0
jsonschema==4.25.1
jsonschema-specifications==2025.9.1
kaitaistruct==0.11
langdetect==1.0.9
linkify-it-py==2.0.3
markdown-it-py==4.0.0
MarkupSafe==3.0.3
mdit-py-plugins==0.5.0
mdurl==0.1.2
mmh3==5.2.0
mpmath==1.3.0
multidict==6.7.0
multiprocess==0.70.18
mypy_extensions==1.1.0
nest-asyncio==1.6.0
networkx==3.5
nltk==3.9.2
numpy==2.3.5
nvidia-cublas-cu12==12.8.4.1
nvidia-cuda-cupti-cu12==12.8.90
nvidia-cuda-nvrtc-cu12==12.8.93
nvidia-cuda-runtime-cu12==12.8.90
nvidia-cudnn-cu12==9.10.2.21
nvidia-cufft-cu12==11.3.3.83
nvidia-cufile-cu12==1.13.1.3
nvidia-curand-cu12==10.3.9.90
nvidia-cusolver-cu12==11.7.3.90
nvidia-cusparse-cu12==12.5.8.93
nvidia-cusparselt-cu12==0.7.1
nvidia-nccl-cu12==2.27.5
nvidia-nvjitlink-cu12==12.8.93
nvidia-nvshmem-cu12==3.3.20
nvidia-nvtx-cu12==12.8.90
openai==2.8.1
packaging==25.0
pandas==2.3.3
pathlib_abc==0.5.2
pathspec==0.12.1
pdfminer.six==20250506
pillow==12.0.0
platformdirs==4.5.0
ply==3.11
polyfile-weave==0.5.7
propcache==0.4.1
protobuf==6.33.1
psutil==7.1.3
pyarrow==22.0.0
pyasn1==0.6.1
pyasn1_modules==0.4.2
pycparser==2.23
pydantic==2.11.7
pydantic-settings==2.12.0
pydantic_core==2.33.2
Pygments==2.19.2
python-dateutil==2.9.0.post0
python-dotenv==1.2.1
pytokens==0.3.0
pytz==2025.2
PyYAML==6.0.3
referencing==0.37.0
regex==2025.11.3
requests==2.32.5
requests-toolbelt==1.0.0
rich==14.2.0
rouge==1.0.1
rpds-py==0.29.0
rsa==4.9.1
s3fs==2025.9.0
s3transfer==0.14.0
safetensors==0.7.0
scikit-learn==1.7.2
scipy==1.16.3
semver==3.0.4
sentence-transformers==5.1.1
sentencepiece==0.2.1
sentry-sdk==2.45.0
shellingham==1.5.4
shortuuid==1.0.13
six==1.17.0
smmap==5.0.2
sniffio==1.3.1
sortedcontainers==2.4.0
soupsieve==2.8
stdlib-list==0.11.1
sympy==1.14.0
tenacity==9.1.2
textual==6.6.0
threadpoolctl==3.6.0
tiktoken==0.12.0
tokenizers==0.22.1
toml==0.10.2
torch==2.9.1
tqdm==4.67.1
transformers==4.57.1
triton==3.5.1
typer==0.20.0
typing-inspection==0.4.2
typing_extensions==4.15.0
tzdata==2025.2
uc-micro-py==1.0.3
universal_pathlib==0.3.6
urllib3==2.5.0
uv==0.9.10
vaderSentiment==3.3.2
wandb==0.23.0
weave==0.52.1
websockets==15.0.1
wrapt==1.17.3
xxhash==3.6.0
yarl==1.22.0
zipp==3.23.0
```