### PR TITLE
chore(inspect_ai_evals): remove optional text for tokens

### DIFF
--- a/jobs/inspect_ai_evals/api_model/sample-schema.json
+++ b/jobs/inspect_ai_evals/api_model/sample-schema.json
@@ -160,13 +160,13 @@
     "hf_token": {
       "type": "string",
       "title": "Hugging Face token",
-      "description": "(Optional) Personal access token used to read gated datasets from Hugging Face.",
+      "description": "Personal access token used to read gated datasets from Hugging Face.",
       "format": "secret"
     },
     "scorer_api_key": {
       "type": "string",
       "title": "Scorer API key",
-      "description": "(Optional) Some evals use an OpenAI model as the default scorer.",
+      "description": "Some evals use an OpenAI model as the default scorer.",
       "format": "secret"
     }
   }

--- a/jobs/inspect_ai_evals/model_checkpoint/sample-schema-model-checkpoint.json
+++ b/jobs/inspect_ai_evals/model_checkpoint/sample-schema-model-checkpoint.json
@@ -138,13 +138,13 @@
     "hf_token": {
       "type": "string",
       "title": "Hugging Face token",
-      "description": "(Optional) Personal access token used to read gated datasets from Hugging Face.",
+      "description": "Personal access token used to read gated datasets from Hugging Face.",
       "format": "secret"
     },
     "scorer_api_key": {
       "type": "string",
       "title": "Scorer API key",
-      "description": "(Optional) Some evals use an OpenAI model as the default scorer.",
+      "description": "Some evals use an OpenAI model as the default scorer.",
       "format": "secret"
     }
   }


### PR DESCRIPTION
A bit misleading now since, when they appear, they're actually required.