### PR TITLE
chore(inspect_ai_evals): add upper range to wandb dep version

### DIFF
--- a/jobs/inspect_ai_evals/pyproject.toml
+++ b/jobs/inspect_ai_evals/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "pydantic-core==2.33.2",
     "pydantic-settings>=2.10.1",
     "sympy>=1.14.0",
-    "wandb>=0.19.11",
+    "wandb==0.22.3",  # pinned to prevent api key validation issues when using an internal jwt as api key
     "weave>=0.51.59",
     "google-genai",
     "rouge",


### PR DESCRIPTION
this pr adds an upper range to the `wandb` dependency which is required for us to use the internal access token as the api key. Later versions will prevent this from working due to validation changes.

tested on QA w/ internal JWT changes