### PR TITLE
feat(sandbox): add sandbox executor launch job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,6 @@ workflows:
                   "jobs/hello_world",
                   "jobs/http_webhook",
                   "jobs/inspect_ai_evals/model_checkpoint",
-                  "jobs/inspect_ai_evals/api_model",
                   "jobs/msft_teams_webhook",
                   "jobs/openai_evals",
                   "jobs/sql_query",

--- a/jobs/inspect_ai_evals/api_model/Dockerfile.wandb
+++ b/jobs/inspect_ai_evals/api_model/Dockerfile.wandb
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.4
 FROM python:3.11-slim
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
@@ -9,15 +10,40 @@ RUN pip install uv
 
 WORKDIR /workspace
 
+# Install local-only deps (not on PyPI).
+# Build with: --build-context aviato-client=<path> --build-context inspect-aviato-sandbox=<path>
+COPY --link --from=aviato-client . /tmp/aviato-client
+RUN pip install --no-cache-dir --extra-index-url https://buf.build/gen/python /tmp/aviato-client && rm -rf /tmp/aviato-client
+
+COPY --link --from=inspect-aviato-sandbox . /tmp/inspect-aviato-sandbox
+RUN pip install --no-cache-dir --no-deps /tmp/inspect-aviato-sandbox && rm -rf /tmp/inspect-aviato-sandbox
+
 # Copy shared files from parent directory
-COPY pyproject.toml launch_secrets.py leaderboard.py ./
+COPY pyproject.toml leaderboard.py ./
 
 # Copy job-specific files from subdirectory
 COPY api_model/ ./
 
 ENV UV_LINK_MODE=copy
+# Pre-install CPU-only PyTorch (~200MB vs ~2GB with CUDA) — evals hit LLM APIs, not local GPUs.
+RUN --mount=type=cache,target=/root/.cache/uv uv pip install torch torchvision \
+    --index-url https://download.pytorch.org/whl/cpu --system
 RUN --mount=type=cache,target=/root/.cache/uv uv pip install -r pyproject.toml --system
 
 ENV PYTHONUNBUFFERED=1
 
-CMD ["/bin/sh", "-c", "python3 evals.py"]
+# Build locally since aviato-client and inspect-aviato-sandbox are not published.
+# Run from the launch-jobs repo root:
+# CI=1 python3 -c "
+# from docker_build import build
+# build(
+#     image='exianwb/inspect_ai_evals',
+#     context_path='jobs/inspect_ai_evals',
+#     dockerfile='jobs/inspect_ai_evals/api_model/Dockerfile.wandb',
+#     build_contexts={
+#         'aviato-client': '../aviato-client',
+#         'inspect-aviato-sandbox': '../inspect_aviato_sandbox',
+#     },
+#     platforms=['linux/amd64', 'linux/arm64'],
+# )
+# "

--- a/jobs/inspect_ai_evals/api_model/evals.py
+++ b/jobs/inspect_ai_evals/api_model/evals.py
@@ -1,37 +1,81 @@
+"""Run Inspect AI evaluations.
+
+Thin wrapper around ``inspect_ai.eval_set()`` that adds:
+- W&B run tracking (``wandb.init`` + ``weave.init``)
+- Model name resolution (auto-detect provider, prepend ``openai-api/`` for non-native)
+- Aviato sandbox (always)
+- Optional Weave leaderboard publishing
+
+CLI args mirror ``inspect eval`` where possible.  Infrastructure knobs
+(retries, concurrency, log dir) are hardcoded to sensible defaults.
+"""
+
+from __future__ import annotations
+
+import argparse
 import os
+import sys
 
 import wandb
 import weave
 from inspect_ai import eval_set
-from inspect_ai._eval.loader import load_tasks
-from inspect_ai._eval.task import task_with
-from inspect_ai.model import get_model
-from wandb.sdk import launch
 
-from leaderboard import create_leaderboard
-from launch_secrets import get_launch_secret_from_env
+import inspect_aviato_sandbox  # noqa: F401  # registers aviato sandbox environment
+
 from datasets.exceptions import DatasetNotFoundError
+from leaderboard import create_leaderboard
 
 INSPECT_EVAL_PREFIX = "inspect_evals/"
 
 
+def resolve_api_keys(resolved_model: str) -> None:
+    """Map generic secret env vars to the provider-specific names inspect_ai expects.
+
+    The sandbox executor passes secrets as env vars keyed by their config
+    field name (e.g. ``model_api_key``).  This helper re-maps them to the
+    env vars each provider SDK actually reads.
+    """
+    # MODEL_API_KEY → provider-specific env var that inspect_ai expects.
+    # Native:     "provider/model"             → PROVIDER_API_KEY
+    # Non-native: "openai-api/provider/model"  → PROVIDER_API_KEY
+    model_api_key = os.environ.get("MODEL_API_KEY")
+    if model_api_key:
+        provider, *_ = resolved_model.split("/")
+        if provider == "openai-api":
+            _, provider, *_ = resolved_model.split("/")
+        env_var = f"{provider.upper().replace('-', '_')}_API_KEY"
+        os.environ.setdefault(env_var, model_api_key)
+
+    # SCORER_API_KEY → OPENAI_API_KEY (default scorer is OpenAI)
+    scorer_api_key = os.environ.get("SCORER_API_KEY")
+    if scorer_api_key:
+        os.environ.setdefault("OPENAI_API_KEY", scorer_api_key)
+        os.environ.setdefault("AZURE_OPENAI_API_KEY", scorer_api_key)
+
+    # HF_TOKEN → HuggingFace env vars (for gated datasets)
+    hf_token = os.environ.get("HF_TOKEN")
+    if hf_token:
+        os.environ.setdefault("HUGGINGFACE_HUB_TOKEN", hf_token)
+
+# Infrastructure defaults — users don't need to think about these.
+RETRY_ATTEMPTS = 3
+RETRY_WAIT = 10
+MAX_TASKS = 10
+
+
 def get_native_providers() -> set[str]:
     try:
-        # Import the providers module to trigger registration
         from inspect_ai.model._providers import providers  # noqa: F401
         from inspect_ai._util.registry import registry_find, registry_info
 
-        # Find all registered modelapi items
         modelapis = registry_find(lambda info: info.type == "modelapi")
 
-        # Extract provider names (strip the "inspect_ai/" prefix)
         names = set()
         for api in modelapis:
             try:
                 info = registry_info(api)
                 provider_name = info.name.replace("inspect_ai/", "")
-                # Exclude internal/test providers
-                if provider_name not in ["mockllm", "none"]:
+                if provider_name not in ("mockllm", "none"):
                     names.add(provider_name)
             except Exception:
                 continue
@@ -71,7 +115,7 @@ def get_native_providers() -> set[str]:
 INSPECT_NATIVE_PROVIDERS = get_native_providers()
 
 
-def resolve_model_name(model_name: str):
+def resolve_model_name(model_name: str) -> str:
     parts = model_name.split("/", 1)
     if len(parts) < 2:
         raise ValueError("Hint: Model name must be in the format 'provider/model-name'")
@@ -81,120 +125,119 @@ def resolve_model_name(model_name: str):
     return f"openai-api/{model_name}"
 
 
-def main():
-    config = launch.load_wandb_config()
-    with wandb.init(config=dict(config)) as run:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run Inspect AI evaluations")
+    parser.add_argument(
+        "tasks", nargs="+",
+        help="Task names (e.g. swebench mmlu_pro)",
+    )
+    parser.add_argument(
+        "-m", "--model", required=True,
+        help="Model name in provider/model format (e.g. openai/gpt-4o)",
+    )
+    parser.add_argument(
+        "--model-base-url", default=None,
+        help="API base URL for the model endpoint",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=None,
+        help="Max samples per task (0 or omitted = all)",
+    )
+    parser.add_argument(
+        "--create-leaderboard", action="store_true", default=False,
+        help="Publish results to Weave leaderboard",
+    )
+    return parser.parse_args(argv)
+
+
+def setup_env(model_name: str, base_url: str | None = None) -> str:
+    """Resolve model name and set env vars for inspect_ai.
+
+    Returns the resolved model name.
+    """
+    resolved = resolve_model_name(model_name)
+
+    if base_url:
+        provider = model_name.split("/", 1)[0]
+        env_var = f"{provider.upper().replace('-', '_')}_BASE_URL"
+        os.environ.setdefault(env_var, base_url)
+
+    os.environ.setdefault("INSPECT_EVAL_MODEL", resolved)
+    resolve_api_keys(resolved)
+    return resolved
+
+
+def run_eval(args: argparse.Namespace) -> int:
+    """Run Inspect AI evaluations. Returns 0 on success, 1 on failure."""
+    try:
+        resolved = setup_env(args.model, args.model_base_url)
+    except ValueError as e:
+        wandb.termerror(str(e))
+        return 1
+
+    task_names = [
+        t if "/" in t else f"{INSPECT_EVAL_PREFIX}{t}" for t in args.tasks
+    ]
+
+    with wandb.init(config={"model": args.model, "tasks": args.tasks}) as run:
         weave_client = weave.init(f"{run.entity}/{run.project}")
 
-        _, hf_token = get_launch_secret_from_env("hf_token", run.config)
-        if hf_token:
-            os.environ.setdefault("HUGGINGFACE_HUB_TOKEN", hf_token)
-            os.environ.setdefault("HF_TOKEN", hf_token)
-            os.environ.setdefault("HUGGINGFACE_TOKEN", hf_token)
-
-        api_key_name, api_key = get_launch_secret_from_env(
-            "api_key_var", run.config.get("model", {})
-        )
-        if api_key_name and api_key:
-            os.environ.setdefault(api_key_name, api_key)
-
-        # Some evals use hosted models as the default scorer.
-        # These could be OpenAI, Anthropic, or Google models.
-        # * For OpenAI, the API key name is "OPENAI_API_KEY".
-        # * For Anthropic, the API key name is "ANTHROPIC_API_KEY".
-        # * For Google, the API key name is "GOOGLE_API_KEY".
-        # Otherwise, we can try to use the model selected by the user (see INSPECT_GRADER_MODEL below)
-        scorer_api_key_name, scorer_api_key = get_launch_secret_from_env(
-            "scorer_api_key", run.config
-        )
-        if scorer_api_key_name and scorer_api_key:
-            os.environ.setdefault(scorer_api_key_name, scorer_api_key)
-
         try:
-            model_name = run.config.get("model", {}).get("model_name")
-            base_url = run.config.get("model", {}).get("base_url", None)
-            if not model_name:
-                wandb.termerror("Hint: Model name is required")
-                weave_client.finish()
-                return
-
-            try:
-                resolved_model_name = resolve_model_name(model_name)
-            except ValueError as e:
-                wandb.termerror(f"Invalid model name: {model_name}. {e}")
-                weave_client.finish()
-                raise e
-
-            if resolved_model_name.startswith("openai-api/"):
-                provider = resolved_model_name.split("/")[1]
-                os.environ.setdefault(
-                    f"{provider.upper().replace('-', '_')}_BASE_URL", base_url
-                )
-
-            model = get_model(resolved_model_name, api_key=api_key, base_url=base_url)
-
-            os.environ.setdefault("INSPECT_EVAL_MODEL", resolved_model_name)
-            os.environ.setdefault("INSPECT_GRADER_MODEL", resolved_model_name)
-        except Exception as e:
-            wandb.termerror(f"Error initializing model: {e}")
+            success, logs = eval_set(
+                tasks=task_names,
+                model=resolved,
+                model_base_url=args.model_base_url,
+                sandbox="aviato",
+                limit=args.limit or None,
+                log_dir="logs/",
+                log_dir_allow_dirty=True,
+                retry_attempts=RETRY_ATTEMPTS,
+                retry_wait=RETRY_WAIT,
+                max_tasks=MAX_TASKS,
+            )
+        except DatasetNotFoundError as e:
+            wandb.termerror(f"Evaluation failed: {e}")
             wandb.termlog(
-                "Hint: Please check if the job inputs for the model is correct ('Name' and 'API Key')"
+                "Hint: This may be a gated dataset. Please check that you have "
+                "set the 'Hugging Face Token' in the job input and have accepted "
+                "the agreement on Hugging Face."
             )
-            weave_client.finish()
-            raise e
-
-        failed_tasks = []
-        for task in run.config.get("tasks", []):
-            try:
-                loaded_task = [
-                    task_with(
-                        load_tasks([f"{INSPECT_EVAL_PREFIX}{task}"])[0], model=model
-                    )
-                ]
-                sample_limit = run.config.get("limit", None)
-                success, _ = eval_set(
-                    tasks=loaded_task,
-                    log_dir="logs/",
-                    limit=sample_limit
-                    if sample_limit
-                    else None,  # evaluate all samples if sample_limit is set to 0
-                    retry_attempts=1,
-                    retry_wait=10,
-                    log_dir_allow_dirty=True,
-                )
-
-                if not success:
-                    wandb.termerror(f"Task {task} did not run successfully")
-                    failed_tasks.append(
-                        (
-                            task,
-                            Exception(
-                                "Task did not complete successfully. Check the logs for more details."
-                            ),
-                        )
-                    )
-                    continue
-
-                if run.config.get("create_leaderboard", True):
-                    create_leaderboard()
-
-            except Exception as e:
-                wandb.termerror(f"Task {task} failed to run")
-                failed_tasks.append((task, e))
-
-        if failed_tasks:
-            wandb.termerror(
-                f"The following tasks failed to run: {[task for (task, _) in failed_tasks]}"
-            )
-            for task, e in failed_tasks:
-                wandb.termerror(f"Task {task} failed to run with error: {e}")
-                if isinstance(e, DatasetNotFoundError):
-                    wandb.termlog(
-                        "Hint: This may be a gated dataset. Please check that you have set the 'Hugging Face Token' in the job input and have accepted the agreement on Hugging Face."
-                    )
             run.finish(exit_code=1)
+            weave_client.finish()
+            return 1
+        except Exception as e:
+            wandb.termerror(f"Evaluation failed: {e}")
+            wandb.termlog(
+                "Hint: Please check that the model name and API key are correct."
+            )
+            run.finish(exit_code=1)
+            weave_client.finish()
+            return 1
 
+        if not success:
+            for log in logs:
+                if log.status != "success":
+                    wandb.termerror(f"Task {log.eval.task}: {log.status}")
+                    if log.error:
+                        wandb.termerror(log.error.message)
+            run.finish(exit_code=1)
+            weave_client.finish()
+            return 1
+
+        if args.create_leaderboard:
+            try:
+                create_leaderboard()
+            except Exception as e:
+                wandb.termerror(f"Leaderboard publishing failed: {e}")
+
+        run.finish(exit_code=0)
         weave_client.finish()
+        return 0
+
+
+def main():
+    args = parse_args()
+    sys.exit(run_eval(args))
 
 
 if __name__ == "__main__":

--- a/jobs/inspect_ai_evals/api_model/sample-schema.json
+++ b/jobs/inspect_ai_evals/api_model/sample-schema.json
@@ -1,6 +1,15 @@
 {
   "type": "object",
   "properties": {
+    "image":           { "type": "string" },
+    "command":         { "type": "string" },
+    "args":            { "type": "array", "items": { "type": "string" } },
+    "env_vars":        { "type": "object" },
+    "resources":       { "type": "object" },
+    "timeout":         { "type": "number" },
+    "files_artifact":  { "type": "string" },
+    "tags":            { "type": "array", "items": { "type": "string" } },
+    "tower_ids":       { "type": "array", "items": { "type": "string" } },
     "tasks": {
       "type": "array",
       "title": "Evaluations",
@@ -105,6 +114,7 @@
           "squad",
           "stereoset",
           "strong_reject",
+          "swebench",
           "sycophancy",
           "truthfulqa",
           "uccb",
@@ -127,33 +137,24 @@
       "placeholder": "E.g. 5",
       "minimum": 0
     },
-    "model": {
-      "type": "object",
-      "title": "Model",
-      "description": "Model to use for the evaluation job",
-      "properties": {
-        "model_name": {
-          "type": "string",
-          "title": "Model name",
-          "description": "Name of the model to use for the evaluation job.",
-          "placeholder": "openai/gpt-4o",
-          "required": true
-        },
-        "base_url": {
-          "type": "string",
-          "title": "Base URL",
-          "description": "Base URL for the model to use for the evaluation job.",
-          "placeholder": "https://api.openai.com/v1",
-          "required": true
-        },
-        "api_key_var": {
-          "type": "string",
-          "title": "API key",
-          "description": "API key for model access. Team secrets can be managed in your team settings by team admins.",
-          "format": "secret",
-          "required": true
-        }
-      }
+    "model_name": {
+      "type": "string",
+      "title": "Model name",
+      "description": "Name of the model to use for the evaluation job.",
+      "placeholder": "openai/gpt-4o",
+      "required": true
+    },
+    "model_base_url": {
+      "type": "string",
+      "title": "Base URL",
+      "description": "Base URL for the model API endpoint.",
+      "placeholder": "https://api.openai.com/v1"
+    },
+    "model_api_key": {
+      "type": "string",
+      "title": "API key",
+      "format": "secret",
+      "description": "API key for model access. Team secrets can be managed in your team settings by team admins."
     },
     "create_leaderboard": {
       "type": "boolean",
@@ -172,6 +173,11 @@
       "title": "Scorer API key",
       "description": "Some evals use an OpenAI model as the default scorer.",
       "format": "secret"
+    },
+    "wandb_api_key": {
+      "type": "string",
+      "format": "secret",
+      "title": "W&B API key"
     }
   }
 }

--- a/jobs/inspect_ai_evals/pyproject.toml
+++ b/jobs/inspect_ai_evals/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-inspect-evals = { git = "https://github.com/UKGovernmentBEIS/inspect_evals" }
+inspect-evals = { git = "https://github.com/iiilisan/inspect_evals", branch = "wandb" }
 inspect-wandb = { git = "https://github.com/parambharat/inspect_wandb.git" }
 instruction-following-eval = { git = "https://github.com/josejg/instruction_following_eval.git" }
 

--- a/jobs/sandbox/Dockerfile.wandb
+++ b/jobs/sandbox/Dockerfile.wandb
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1.4
+FROM python:3.11-slim
+
+WORKDIR /launch
+
+# Install aviato-client from local source (not on PyPI).
+# Build with: --build-context aviato-client=<path-to-aviato-client>
+COPY --link --from=aviato-client . /tmp/aviato-client
+RUN pip install --no-cache-dir --extra-index-url https://buf.build/gen/python /tmp/aviato-client && rm -rf /tmp/aviato-client
+
+COPY --link requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY --link job.py ./
+
+ENV PYTHONUNBUFFERED=1
+ENTRYPOINT ["python", "job.py"]
+
+# Build locally for now since aviato-client is not published to a registry.
+# Run from the launch-jobs repo root:
+# CI=1 python3 -c "
+# from docker_build import build
+# build(
+#     image='exianwb/launch_sandbox',
+#     context_path='jobs/sandbox',
+#     dockerfile='jobs/sandbox/Dockerfile.wandb',
+#     build_contexts={'aviato-client': '../aviato-client'},
+#     platforms=['linux/amd64', 'linux/arm64'],
+# )
+# "

--- a/jobs/sandbox/configs/example.yml
+++ b/jobs/sandbox/configs/example.yml
@@ -1,0 +1,7 @@
+run_name: Sandbox Executor Example
+config:
+  command: python
+  args:
+    - main.py
+  image: "python:3.11"
+  timeout: 3600

--- a/jobs/sandbox/job.py
+++ b/jobs/sandbox/job.py
@@ -1,0 +1,175 @@
+"""Sandbox executor launch job.
+
+Reads run config from wandb launch, resolves ``secret://`` references from
+the container's environment (where launch injected them), and starts an
+aviato sandbox.
+
+The run_config should contain only sandbox primitives — the CLI is
+responsible for putting everything the sandbox image needs into
+``command``/``args`` and ``env_vars``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import tempfile
+from typing import Any
+
+import wandb
+from aviato import Sandbox
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+from wandb.sdk import launch
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+_SECRET_PREFIX = "secret://"
+
+
+class MountedFile(BaseModel):
+    path: str
+    content: str
+
+
+class SandboxConfig(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    image: str
+    command: str | None = None
+    args: list[str] = Field(default_factory=list)
+    env_vars: dict[str, str] = Field(default_factory=dict)
+    resources: dict[str, Any] | None = None
+    timeout: float | None = None
+    files_artifact: str | None = None
+    tags: list[str] | None = None
+    tower_ids: list[str] | None = None
+
+    @model_validator(mode="after")
+    def _check_args_require_command(self) -> SandboxConfig:
+        if self.command is None and self.args:
+            raise ValueError(
+                "'args' were provided but 'command' is not set — "
+                "set 'command' or remove 'args'"
+            )
+        return self
+
+
+def _resolve_secrets(config: dict) -> dict[str, str]:
+    """Resolve ``secret://`` references from the container environment.
+
+    Returns a dict keyed by the config field name, with the resolved
+    secret value.  e.g. ``{"model_api_key": "<actual-value>"}``.
+    """
+    resolved = {}
+    for field, ref in config.items():
+        if not isinstance(ref, str) or not ref.startswith(_SECRET_PREFIX):
+            continue
+        env_name = ref[len(_SECRET_PREFIX):].upper()
+        env_value = os.environ.get(env_name)
+        if env_value is not None:
+            resolved[field.upper()] = env_value
+        else:
+            logger.warning(
+                "secret ref %s for field %s could not be resolved — "
+                "%s not in container env",
+                ref, field, env_name,
+            )
+    return resolved
+
+
+config = launch.load_wandb_config()
+
+logger.info("Loaded run config: %s", json.dumps(dict(config), indent=2))
+
+sandbox_config = SandboxConfig(**config)
+logger.info("Parsed env_vars from config: %s", sandbox_config.env_vars)
+
+resolved_secrets = _resolve_secrets(config)
+logger.info("Resolved secret keys: %s", list(resolved_secrets.keys()))
+
+env = {**sandbox_config.env_vars, **resolved_secrets}
+wandb_api_key = os.environ.get('WANDB_API_KEY')
+if wandb_api_key:
+    env['WANDB_API_KEY'] = wandb_api_key
+else:
+    logger.warning("WANDB_API_KEY is not set — the sandbox will not be able to authenticate with W&B")
+
+logger.info("Final sandbox env keys: %s", sorted(env.keys()))
+
+# Write env vars into the pod's own environment so that wandb.init(),
+# weave.init(), and any other SDK calls in this process can pick them up.
+overwritten = [k for k, v in env.items() if os.environ.get(k) not in (None, v)]
+if overwritten:
+    logger.warning("Overwriting existing env vars: %s", ", ".join(sorted(overwritten)))
+for k, v in env.items():
+    os.environ[k] = v
+
+mounted_files: list[MountedFile] | None = None
+if sandbox_config.files_artifact:
+    api = wandb.Api()
+    artifact = api.artifact(sandbox_config.files_artifact)
+    logger.info("Resolving files artifact %s", sandbox_config.files_artifact)
+
+    # Entry names are relative (leading / stripped by CLI).
+    # Download all files into a temp dir, then reconstruct absolute
+    # mount paths by prepending /.
+    _MAX_MOUNTED_FILE_SIZE = 1 * 1024 * 1024  # 1 MiB
+
+    mounted_files = []
+    with tempfile.TemporaryDirectory() as tmpdir:
+        artifact.download(root=tmpdir)
+        real_tmpdir = os.path.realpath(tmpdir)
+        for entry in artifact.manifest.entries.values():
+            norm_path = os.path.normpath(entry.path)
+            if os.path.isabs(norm_path) or norm_path.startswith(".."):
+                raise ValueError(
+                    f"Artifact entry has unsafe path: {entry.path}"
+                )
+            file_path = os.path.join(tmpdir, norm_path)
+            if not os.path.realpath(file_path).startswith(real_tmpdir + os.sep):
+                raise ValueError(
+                    f"Artifact entry escapes temp directory: {entry.path}"
+                )
+            file_size = os.path.getsize(file_path)
+            if file_size > _MAX_MOUNTED_FILE_SIZE:
+                logger.warning(
+                    "File %s is %d bytes which exceeds the 1 MiB mounted "
+                    "file size limit — sandbox creation may fail.",
+                    entry.path, file_size,
+                )
+            try:
+                with open(file_path, encoding="utf-8") as f:
+                    content = f.read()
+            except UnicodeDecodeError:
+                raise ValueError(
+                    f"Artifact file {entry.path} is not valid UTF-8 — "
+                    "mounted files only support text content"
+                )
+            mounted_files.append(MountedFile(path="/" + norm_path, content=content))
+
+if sandbox_config.command is not None:
+    cmd_args = [sandbox_config.command, *sandbox_config.args]
+else:
+    cmd_args = []
+logger.info("Starting sandbox: image=%s command=%s args=%s", sandbox_config.image, sandbox_config.command, sandbox_config.args)
+
+mounted_files_dicts = [f.model_dump() for f in mounted_files] if mounted_files else None
+
+with Sandbox.run(
+    *cmd_args,
+    container_image=sandbox_config.image,
+    environment_variables=env,
+    resources=sandbox_config.resources,
+    max_lifetime_seconds=sandbox_config.timeout,
+    mounted_files=mounted_files_dicts,
+    tags=sandbox_config.tags,
+    tower_ids=sandbox_config.tower_ids,
+) as sandbox:
+    logger.info("Sandbox running: id=%s tower=%s", sandbox.sandbox_id, sandbox.tower_id)
+    sandbox.wait_until_complete()
+
+logger.info("Sandbox finished: id=%s status=%s exit_code=%s", sandbox.sandbox_id, sandbox.status, sandbox.returncode)
+sys.exit(sandbox.returncode if sandbox.returncode is not None else (0 if sandbox.status == "success" else 1))

--- a/jobs/sandbox/requirements.txt
+++ b/jobs/sandbox/requirements.txt
@@ -1,0 +1,2 @@
+pydantic
+wandb

--- a/jobs/sandbox/schema.json
+++ b/jobs/sandbox/schema.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "properties": {
+    "image":           { "type": "string", "required": true },
+    "command":         { "type": "string" },
+    "args":            { "type": "array", "items": { "type": "string" } },
+    "env_vars":        { "type": "object" },
+    "resources":       { "type": "object" },
+    "timeout":         { "type": "number" },
+    "files_artifact":  { "type": "string" },
+    "tags":            { "type": "array", "items": { "type": "string" } },
+    "tower_ids":       { "type": "array", "items": { "type": "string" } }
+  }
+}


### PR DESCRIPTION
## Summary

**feat(sandbox): add sandbox executor launch job**
- Add a new launch job (`jobs/sandbox/`) that runs commands inside an aviato sandbox container
- Reads run config from W&B Launch, forwards app config and resolved secrets into the sandbox via environment variables
- Supports configurable commands, env var secret resolution, file mounting via artifacts, and resource/timeout settings

**refactor(inspect_ai_evals): decouple eval logic from W&B Launch internals**
- `evals.py` was tightly coupled to launch internals (`load_wandb_config`, `get_launch_secret_from_env`, etc.). Now that the sandbox executor handles all launch integration, `evals.py` is a pure CLI wrapper around `eval_set()` — receiving tasks, model, and options as CLI args instead of parsing run config
- Secrets are injected as plain env vars by the sandbox executor, removing the need for `secret://` config refs in eval code
- The Dockerfile now installs `aviato-client` and `inspect-aviato-sandbox` from local build contexts (not yet published to PyPI) and pins `inspect-evals` to the `iiilisan/inspect_evals@wandb` fork