### PR TITLE
chore(security): enable Renovate for GitHub Actions SHA pinning

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>wandb/renovate-config"]
+}


### PR DESCRIPTION
## Required: enable Renovate for GitHub Actions SHA pinning

This PR is part of an AppSec-mandated rollout across every wandb repo with
GitHub Actions workflows. All targeted repos are required to merge.

Tracking: [APPSEC-2175](https://coreweave.atlassian.net/browse/APPSEC-2175).
Full architecture + ops details:
[W&B Renovate GitHub Actions doc](https://coreweave.atlassian.net/wiki/spaces/SECURITY/pages/1720418506).

## What this PR does

Adds `.github/renovate.json5` extending the shared wandb Renovate preset.
Renovate runs centrally from
[`wandb/renovate-config`](https://github.com/wandb/renovate-config) on a
daily cron — no workflow file added to your repo.

## Why this is mandatory

GitHub Actions tags can be silently repointed by attackers. CoreWeave was
hit twice in the past year — `aquasecurity/trivy-action` (March 2026)
and `tj-actions/changed-files` (March 2025). Pinning every `uses:` to a
40-char commit SHA eliminates this attack vector. AppSec is enforcing
this org-wide.

## What happens after you merge

Within ~24 hours, Renovate opens a follow-up PR pinning every
`uses: action@<tag>` reference in your workflows to a 40-char commit SHA.
Version tags are preserved as trailing comments so diffs stay readable.

Going forward:

- Patch/minor SHA bumps: auto-PR after a 7-day release-age wait
- Major bumps: surfaced on the repo's Dependency Dashboard issue, opt-in
- Other dep managers (pip, terraform, docker): not touched

## Required action

1. Merge this PR
2. Merge the follow-up SHA-pin PR from `wandb-renovate[bot]` (opens within 24 hours)
3. Merge ongoing SHA-bump PRs from `wandb-renovate[bot]` as they appear

## Technical blockers

If you have a concrete technical blocker (e.g. workflows referencing
internal-only refs that can't be SHA-pinned), reach out to
`@coreweave/application-security` in `#application-security` so we can
work through it together.

[_Created by Sourcegraph batch change `shivawandb/enable-renovate-wandb-org`._](https://coreweave.sourcegraphcloud.com/users/shivawandb/batch-changes/enable-renovate-wandb-org)

[APPSEC-2175]: https://coreweave.atlassian.net/browse/APPSEC-2175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ