### PR TITLE
ci: migrate image publishing to GitHub Actions

### DIFF
--- a/.github/IMAGE_PUBLISHING.md
+++ b/.github/IMAGE_PUBLISHING.md
@@ -1,0 +1,43 @@
+# Image publishing credentials
+
+The `Publish changed images` workflow publishes to the `wandb` namespace on Docker Hub. It uses these GitHub Actions repository secrets:
+
+- `DOCKERHUB_USERNAME`: a W&B-managed Docker Hub service account
+- `DOCKERHUB_TOKEN`: an access token for that account with permission to push to the `wandb` repositories listed in `.github/image-builds.json`
+
+Do not use a personal account or a Docker Hub password.
+
+## Initial setup
+
+A Docker Hub organization owner must create or select the service account and create its access token. GitHub does not expose existing secret values, and a workflow must not create its own long-lived publishing credential.
+
+A GitHub repository administrator can then store the credentials without putting them on the command line or in shell history:
+
+```bash
+read -r -p "Docker Hub username: " DOCKERHUB_USERNAME
+read -r -s -p "Docker Hub access token: " DOCKERHUB_TOKEN
+echo
+gh secret set DOCKERHUB_USERNAME --repo wandb/launch-jobs --body "$DOCKERHUB_USERNAME"
+gh secret set DOCKERHUB_TOKEN --repo wandb/launch-jobs --body "$DOCKERHUB_TOKEN"
+unset DOCKERHUB_USERNAME DOCKERHUB_TOKEN
+```
+
+The repository had a `DOCKERHUB_TOKEN` secret before this migration, but its value cannot be inspected. Rotate it rather than assuming it belongs to the service account used by CircleCI.
+
+## Rotation
+
+1. Create a new access token for the service account in Docker Hub. Do not revoke the old token yet.
+2. Replace `DOCKERHUB_TOKEN` with `gh secret set` as shown above. Update `DOCKERHUB_USERNAME` too if the account changed.
+3. Run `Publish changed images` manually for one normal image, such as `job_hello_world`.
+4. Run it for one shared-context image, such as `job_inspect_ai_evals_api_model`.
+5. Confirm both SHA tags and multi-platform manifests in Docker Hub.
+6. Revoke the old Docker Hub token.
+
+During the CircleCI parity period, determine whether CircleCI uses the same token before revoking it. If it does, either update CircleCI as well or retain the old token until CircleCI is disabled.
+
+Repository administrators can verify secret presence and rotation timestamps, but not secret values:
+
+```bash
+gh api repos/wandb/launch-jobs/actions/secrets \
+  --jq '.secrets[] | select(.name | startswith("DOCKERHUB_")) | [.name, .updated_at] | @tsv'
+```

--- a/.github/IMAGE_PUBLISHING.md
+++ b/.github/IMAGE_PUBLISHING.md
@@ -11,18 +11,31 @@ Do not use a personal account or a Docker Hub password.
 
 A Docker Hub organization owner must create or select the service account and create its access token. GitHub does not expose existing secret values, and a workflow must not create its own long-lived publishing credential.
 
-A GitHub repository administrator can then store the credentials without putting them on the command line or in shell history:
+A GitHub repository administrator can then store the credentials without putting them in process arguments or shell history. Each command securely prompts for its value:
 
 ```bash
-read -r -p "Docker Hub username: " DOCKERHUB_USERNAME
-read -r -s -p "Docker Hub access token: " DOCKERHUB_TOKEN
-echo
-gh secret set DOCKERHUB_USERNAME --repo wandb/launch-jobs --body "$DOCKERHUB_USERNAME"
-gh secret set DOCKERHUB_TOKEN --repo wandb/launch-jobs --body "$DOCKERHUB_TOKEN"
-unset DOCKERHUB_USERNAME DOCKERHUB_TOKEN
+gh secret set DOCKERHUB_USERNAME --repo wandb/launch-jobs
+gh secret set DOCKERHUB_TOKEN --repo wandb/launch-jobs
 ```
 
 The repository had a `DOCKERHUB_TOKEN` secret before this migration, but its value cannot be inspected. Rotate it rather than assuming it belongs to the service account used by CircleCI.
+
+## Initial rollout
+
+Push-triggered publishing is disabled unless the repository variable `IMAGE_PUBLISHING_ENABLED` is exactly `true`. Manual runs remain available while publishing is disabled, preventing the merge that adds the image manifest from publishing all images immediately.
+
+After configuring the secrets:
+
+1. Run `Publish changed images` manually for `job_hello_world`.
+2. Run it manually for `job_inspect_ai_evals_api_model` to exercise the shared context.
+3. Confirm both SHA and branch tags, digests, and multi-platform manifests in Docker Hub.
+4. Enable push-triggered publishing:
+
+   ```bash
+   gh variable set IMAGE_PUBLISHING_ENABLED --repo wandb/launch-jobs --body true
+   ```
+
+Disable automatic publishing without affecting manual runs by setting the variable to `false`.
 
 ## Rotation
 
@@ -30,7 +43,7 @@ The repository had a `DOCKERHUB_TOKEN` secret before this migration, but its val
 2. Replace `DOCKERHUB_TOKEN` with `gh secret set` as shown above. Update `DOCKERHUB_USERNAME` too if the account changed.
 3. Run `Publish changed images` manually for one normal image, such as `job_hello_world`.
 4. Run it for one shared-context image, such as `job_inspect_ai_evals_api_model`.
-5. Confirm both SHA tags and multi-platform manifests in Docker Hub.
+5. Confirm the SHA and branch tags, digests, and multi-platform manifests in Docker Hub.
 6. Revoke the old Docker Hub token.
 
 During the CircleCI parity period, determine whether CircleCI uses the same token before revoking it. If it does, either update CircleCI as well or retain the old token until CircleCI is disabled.

--- a/.github/image-builds.json
+++ b/.github/image-builds.json
@@ -1,0 +1,86 @@
+{
+  "images": [
+    {
+      "path": "jobs/deploy_to_nvidia_triton",
+      "image": "job_deploy_to_nvidia_triton"
+    },
+    {
+      "path": "jobs/deploy_to_sagemaker_endpoints",
+      "image": "job_deploy_to_sagemaker_endpoints"
+    },
+    {
+      "path": "jobs/distributed_test",
+      "image": "job_distributed_test"
+    },
+    {
+      "path": "jobs/fashion_mnist_train",
+      "image": "job_fashion_mnist_train"
+    },
+    {
+      "path": "jobs/github_actions_workflow_dispatch",
+      "image": "job_github_actions_workflow_dispatch"
+    },
+    {
+      "path": "jobs/gpu_optimize_with_tensor_rt",
+      "image": "job_gpu_optimize_with_tensor_rt"
+    },
+    {
+      "path": "jobs/hello_world",
+      "image": "job_hello_world"
+    },
+    {
+      "path": "jobs/http_webhook",
+      "image": "job_http_webhook"
+    },
+    {
+      "path": "jobs/inspect_ai_evals/model_checkpoint",
+      "image": "job_inspect_ai_evals_model_checkpoint",
+      "context": "jobs/inspect_ai_evals",
+      "dockerfile": "jobs/inspect_ai_evals/model_checkpoint/Dockerfile.wandb",
+      "shared_path": "jobs/inspect_ai_evals",
+      "shared_exclude_paths": [
+        "jobs/inspect_ai_evals/api_model",
+        "jobs/inspect_ai_evals/model_checkpoint"
+      ]
+    },
+    {
+      "path": "jobs/inspect_ai_evals/api_model",
+      "image": "job_inspect_ai_evals_api_model",
+      "context": "jobs/inspect_ai_evals",
+      "dockerfile": "jobs/inspect_ai_evals/api_model/Dockerfile.wandb",
+      "shared_path": "jobs/inspect_ai_evals",
+      "shared_exclude_paths": [
+        "jobs/inspect_ai_evals/api_model",
+        "jobs/inspect_ai_evals/model_checkpoint"
+      ]
+    },
+    {
+      "path": "jobs/msft_teams_webhook",
+      "image": "job_msft_teams_webhook"
+    },
+    {
+      "path": "jobs/openai_evals",
+      "image": "job_openai_evals"
+    },
+    {
+      "path": "jobs/sql_query",
+      "image": "job_sql_query"
+    },
+    {
+      "path": "jobs/stable_diffusion_inference",
+      "image": "job_stable_diffusion_inference"
+    },
+    {
+      "path": "jobs/sweep_schedulers/optuna_scheduler",
+      "image": "job_sweep_schedulers_optuna_scheduler"
+    },
+    {
+      "path": "jobs/sweep_schedulers/wandb_scheduler",
+      "image": "job_sweep_schedulers_wandb_scheduler"
+    },
+    {
+      "path": "services/vllm_server",
+      "image": "service_vllm_server"
+    }
+  ]
+}

--- a/.github/scripts/select-images.py
+++ b/.github/scripts/select-images.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Select container images affected by a set of changed repository paths."""
+
+import argparse
+import json
+from pathlib import Path, PurePosixPath
+import sys
+
+MANIFEST_PATH = ".github/image-builds.json"
+
+
+def is_within(path: str, directory: str) -> bool:
+    path_parts = PurePosixPath(path).parts
+    directory_parts = PurePosixPath(directory).parts
+    return path_parts[: len(directory_parts)] == directory_parts
+
+
+def load_images(manifest_path: Path) -> list[dict]:
+    images = json.loads(manifest_path.read_text())["images"]
+    names: set[str] = set()
+    paths: set[str] = set()
+
+    for image in images:
+        name = image["image"]
+        path = image["path"].rstrip("/")
+        if name in names:
+            raise ValueError(f"duplicate image name: {name}")
+        if path in paths:
+            raise ValueError(f"duplicate image path: {path}")
+        names.add(name)
+        paths.add(path)
+
+        image["path"] = path
+        image.setdefault("context", path)
+        image.setdefault("dockerfile", f"{path}/Dockerfile.wandb")
+
+        if not Path(image["context"]).is_dir():
+            raise ValueError(f"missing build context for {name}: {image['context']}")
+        if not Path(image["dockerfile"]).is_file():
+            raise ValueError(f"missing Dockerfile for {name}: {image['dockerfile']}")
+
+    return images
+
+
+def affected(image: dict, changed_paths: list[str]) -> bool:
+    for changed_path in changed_paths:
+        if is_within(changed_path, image["path"]):
+            return True
+
+        shared_path = image.get("shared_path")
+        if shared_path and is_within(changed_path, shared_path):
+            excluded = image.get("shared_exclude_paths", [])
+            if not any(is_within(changed_path, path) for path in excluded):
+                return True
+
+    return False
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", default=MANIFEST_PATH, type=Path)
+    parser.add_argument(
+        "--image",
+        default=None,
+        help="Force one image by name, or use 'all' to force every image",
+    )
+    args = parser.parse_args()
+
+    images = load_images(args.manifest)
+    changed_paths = [line.strip() for line in sys.stdin if line.strip()]
+
+    if args.image:
+        if args.image == "all":
+            selected = images
+        else:
+            selected = [image for image in images if image["image"] == args.image]
+            if not selected:
+                raise ValueError(f"unknown image: {args.image}")
+    elif MANIFEST_PATH in changed_paths:
+        selected = images
+    else:
+        selected = [image for image in images if affected(image, changed_paths)]
+
+    matrix = {
+        "include": [
+            {
+                "image": image["image"],
+                "context": image["context"],
+                "dockerfile": image["dockerfile"],
+            }
+            for image in selected
+        ]
+    }
+    print(json.dumps(matrix, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
   select-images:
+    if: github.event_name == 'workflow_dispatch' || vars.IMAGE_PUBLISHING_ENABLED == 'true'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.select.outputs.matrix }}
@@ -49,6 +50,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.select-images.outputs.matrix) }}
+    concurrency:
+      group: publish-image-${{ matrix.image }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
@@ -76,26 +80,37 @@ jobs:
           file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ${{ steps.tags.outputs.branch }}
-            ${{ steps.tags.outputs.sha }}
+          tags: ${{ steps.tags.outputs.sha }}
           cache-from: type=gha,scope=${{ matrix.image }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}
           provenance: false
       - name: Validate published manifest
         env:
-          BRANCH_TAG: ${{ steps.tags.outputs.branch }}
           SHA_TAG: ${{ steps.tags.outputs.sha }}
           DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           test -n "$DIGEST"
-          for tag in "$BRANCH_TAG" "$SHA_TAG"; do
-            published_digest="$(docker buildx imagetools inspect "$tag" | awk '$1 == "Digest:" { print $2; exit }')"
-            test "$published_digest" = "$DIGEST"
-          done
+          published_digest="$(docker buildx imagetools inspect "$SHA_TAG" | awk '$1 == "Digest:" { print $2; exit }')"
+          test "$published_digest" = "$DIGEST"
           manifest="$(docker buildx imagetools inspect --raw "$SHA_TAG")"
           jq -e '
             [.manifests[].platform | "\(.os)/\(.architecture)"]
             | contains(["linux/amd64", "linux/arm64"])
           ' <<< "$manifest"
           echo "Published $SHA_TAG at $DIGEST" >> "$GITHUB_STEP_SUMMARY"
+      - name: Promote current commit to branch tag
+        env:
+          BRANCH_TAG: ${{ steps.tags.outputs.branch }}
+          SHA_TAG: ${{ steps.tags.outputs.sha }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          remote_sha="$(git ls-remote origin "refs/heads/$GITHUB_REF_NAME" | awk '{ print $1 }')"
+          if [[ "$remote_sha" != "$GITHUB_SHA" ]]; then
+            echo "Skipping $BRANCH_TAG: branch has advanced to $remote_sha." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          docker buildx imagetools create --tag "$BRANCH_TAG" "$SHA_TAG@$DIGEST"
+          published_digest="$(docker buildx imagetools inspect "$BRANCH_TAG" | awk '$1 == "Digest:" { print $2; exit }')"
+          test "$published_digest" = "$DIGEST"
+          echo "Promoted $BRANCH_TAG to $DIGEST" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,101 @@
+name: Publish changed images
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "jobs/**"
+      - "services/**"
+      - ".github/image-builds.json"
+  workflow_dispatch:
+    inputs:
+      image:
+        description: "Image name from .github/image-builds.json, or 'all'"
+        required: true
+        default: all
+
+permissions:
+  contents: read
+
+jobs:
+  select-images:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.select.outputs.matrix }}
+      count: ${{ steps.select.outputs.count }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: select
+        name: Select affected images
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
+          FORCED_IMAGE: ${{ inputs.image }}
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            matrix="$(.github/scripts/select-images.py --image "$FORCED_IMAGE")"
+          else
+            matrix="$(git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA" | .github/scripts/select-images.py)"
+          fi
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "count=$(jq '.include | length' <<< "$matrix")" >> "$GITHUB_OUTPUT"
+
+  build-and-push:
+    needs: select-images
+    if: needs.select-images.outputs.count != '0'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.select-images.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - id: tags
+        name: Generate image tags
+        env:
+          IMAGE: ${{ matrix.image }}
+        run: |
+          branch="${GITHUB_REF_NAME//\//-}"
+          {
+            echo "branch=wandb/$IMAGE:$branch"
+            echo "sha=wandb/$IMAGE:$GITHUB_SHA"
+          } >> "$GITHUB_OUTPUT"
+      - id: build
+        name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ steps.tags.outputs.branch }}
+            ${{ steps.tags.outputs.sha }}
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+          provenance: false
+      - name: Validate published manifest
+        env:
+          BRANCH_TAG: ${{ steps.tags.outputs.branch }}
+          SHA_TAG: ${{ steps.tags.outputs.sha }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          test -n "$DIGEST"
+          for tag in "$BRANCH_TAG" "$SHA_TAG"; do
+            published_digest="$(docker buildx imagetools inspect "$tag" | awk '$1 == "Digest:" { print $2; exit }')"
+            test "$published_digest" = "$DIGEST"
+          done
+          manifest="$(docker buildx imagetools inspect --raw "$SHA_TAG")"
+          jq -e '
+            [.manifests[].platform | "\(.os)/\(.architecture)"]
+            | contains(["linux/amd64", "linux/arm64"])
+          ' <<< "$manifest"
+          echo "Published $SHA_TAG at $DIGEST" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -7,4 +7,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: astral-sh/ruff-action@v3
         with:
-          args: "check --fix --exit-non-zero-on-fix --show-fixes --ignore E501"
+          # Keep the historical Ruff defaults explicit so action upgrades do not
+          # silently enable new rule families across the entire repository.
+          args: "check --fix --exit-non-zero-on-fix --show-fixes --select E4,E7,E9,F --ignore E501"


### PR DESCRIPTION
## Summary

Migrate `launch-jobs` image publishing from the nightly CircleCI matrix to path-filtered GitHub Actions builds.

- add a checked-in manifest for the 17 images currently published by CircleCI
- dynamically select only images affected by a push to `main`
- preserve the shared build context and change detection for `jobs/inspect_ai_evals`
- build and push `linux/amd64` and `linux/arm64` images with branch and commit SHA tags
- support forced rebuilds of one image or all images through `workflow_dispatch`
- publish and validate the immutable SHA tag before promoting it to the branch tag
- serialize builds per image and only promote when the commit is still the remote branch head
- gate push-triggered publishing behind `IMAGE_PUBLISHING_ENABLED` while keeping manual canaries available
- document initial Docker Hub credential setup and rotation
- make the repository's historical Ruff rule selection explicit so Ruff upgrades do not silently enable unrelated rule families

CircleCI remains in place for parity testing and is not removed by this PR.

## Docker Hub credentials

**Repository owners will handle this before enabling push-triggered publishing.** The workflow expects a W&B-managed Docker Hub service account in these GitHub Actions repository secrets:

- `DOCKERHUB_USERNAME`
- `DOCKERHUB_TOKEN`

The existing `DOCKERHUB_TOKEN` predates the current CircleCI publisher and cannot be inspected, so it should be rotated rather than assumed to match the current account. Setup and rotation steps are documented in `.github/IMAGE_PUBLISHING.md`.

During the parity period, owners should check whether CircleCI shares the token before revoking the old credential.

## Validation

- parsed the new workflow as YAML
- checked the image manifest against all 17 entries in the CircleCI matrix
- exercised empty, normal-image, shared-context, image-specific, forced-image, and full-manifest selection paths
- ran `python3 -m py_compile .github/scripts/select-images.py`
- ran `git diff --check`

## Cutover follow-ups

- configure/rotate the GitHub Actions Docker Hub secrets
- manually publish and inspect one normal image and one `inspect_ai_evals` image
- set `IMAGE_PUBLISHING_ENABLED=true` after both canaries pass
- disable the external CircleCI daily schedule after parity is confirmed
- remove `.circleci/config.yml` in the final cutover


